### PR TITLE
Fix typos in `jsonstringify` operator docs (PR Maker test)

### DIFF
--- a/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
+++ b/editions/tw5.com/tiddlers/filters/jsonstringify Operator.tid
@@ -1,7 +1,7 @@
 caption: jsonstringify
 created: 20171029155051467
 from-version: 5.1.14
-modified: 20171029155143797
+modified: 20230804111618065
 op-input: a [[selection of titles|Title Selection]]
 op-output: the input with JSON string encodings applied
 op-parameter: 
@@ -13,21 +13,23 @@ tags: [[Filter Operators]] [[String Operators]]
 title: jsonstringify Operator
 type: text/vnd.tiddlywiki
 
+This operator works identically to [[stringify Operator]].
+
 The following substitutions are made:
 
 |!Character |!Replacement |!Condition |
 |`\` |`\\` |Always |
 |`"` |`\"` |Always |
-|Carriage return (0x0d) |`\\r` |Always |
-|Line feed (0x0a) |`\\n` |Always |
-|Backspace (0x08) |`\\b` |Always |
-|Form field (0x0c) |`\\f` |Always |
-|Tab (0x09) |`\\t` |Always |
-|Characters from 0x00 to 0x1f |`\\u####` where #### is four hex digits |Always |
-|Characters from 0x80 to 0xffff|`\\u####` where #### is four hex digits |If `rawunicode` suffix is not present (default) |
+|Carriage return (0x0d) |`\r` |Always |
+|Line feed (0x0a) |`\n` |Always |
+|Backspace (0x08) |`\b` |Always |
+|Form field (0x0c) |`\f` |Always |
+|Tab (0x09) |`\t` |Always |
+|Characters from 0x00 to 0x1f |`\u####` where #### is four hex digits |Always |
+|Characters from 0x80 to 0xffff|`\u####` where #### is four hex digits |If `rawunicode` suffix is not present (default) |
 |Characters from 0x80 to 0xffff|Unchanged |If `rawunicode` suffix is present <<.from-version "5.1.23">> |
 
-<<.from-version "5.1.23">> If the suffix `rawunicode` is present, Unicode characters above 0x80 (such as ß, ä, ñ or 🎄) will be passed through unchanged. Without the suffix, they will be substituted with `\\u` codes, which was the default behavior before 5.1.23.
+<<.from-version "5.1.23">> If the suffix `rawunicode` is present, Unicode characters above 0x80 (such as ß, ä, ñ or 🎄) will be passed through unchanged. Without the suffix, they will be substituted with `\u` codes, which was the default behavior before 5.1.23.
 
 <<.note """Technical note: Characters outside the Basic Multilingual Plane, such as 🎄 and other emojis, will be encoded as a UTF-16 surrogate pair, i.e. with two `\u` sequences.""">>
 


### PR DESCRIPTION
Attempting to save as draft to rest repo. 

---
<small>Submitted using https://saqimtiaz.github.io/tw5-docs-pr-maker/dev/dev.html.</small>

---

Loaded previous changes, made more changes, now attepting to submit as active PR to test repo. 